### PR TITLE
Update typescript version to ^3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   "dependencies": {
     "reflect-metadata": "^0.1.12",
     "tslib": "^1.9.3",
-    "typescript": "^2.9.2"
+    "typescript": "^3.1.2"
   }
 }


### PR DESCRIPTION
Allow generated file to import AbstractClass by relative path instead of alias 
`import("../abstract.class").AbstractClass<D>` instead of `import("@/abstract.class").AbstractClass<D>`